### PR TITLE
fix: bootstrap scss import

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,7 +4,7 @@
 @import "config/bootstrap_variables";
 
 // External libraries
-@import "../../../nodes_modules/bootstrap/scss/bootstrap";
+@import "bootstrap";
 @import "font-awesome-sprockets";
 @import "font-awesome";
 


### PR DESCRIPTION
Heroku deployment do not find relative import paths